### PR TITLE
Removed vavai.com

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -12,7 +12,7 @@ title = Planet openSUSE
   feed     = https://openbuildservice.org/feed/
   link     = https://openbuildservice.org
   location = en
-  avatar   = obs.png
+  avatar   = obs.pnghttps://www.vavai.com/category/linux/
 
 [networkusersinstitute]
   title    = Network Users Institute
@@ -742,12 +742,6 @@ title = Planet openSUSE
   avatar   = thomas_thym.png
   author   = irc:ungethym
 
-[masimvavaisugianto]
-  title    = Masim Vavai Sugianto
-  feed     = https://www.vavai.com/category/linux/feed/
-  link     = https://www.vavai.com/category/linux/
-  location = id
-  author   = irc:vavai member
 
 [andressilva]
   title    = Andres Silva


### PR DESCRIPTION
Removed vavai.com as it doesn't publish any FOSS , Linux or openSUSE related content and only one blog post was posted on /linux and was a hiring post.